### PR TITLE
Move therubyracer to assets group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,10 +10,9 @@ group :assets do
   gem 'sass-rails',   '~> 3.2.3'
   gem 'coffee-rails', '~> 3.2.1'
 
+  # JS Runtime
+  gem 'therubyracer'
   gem 'uglifier', '>= 1.0.3'
 end
 
 gem 'jquery-rails'
-
-# Rubyracer JS runtime environment
-gem 'therubyracer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
       i18n (= 0.6.1)
       multi_json (~> 1.0)
     arel (3.0.2)
-    bcrypt-ruby (3.0.1)
+    bcrypt-ruby (3.1.2)
     builder (3.0.4)
     coffee-rails (3.2.2)
       coffee-script (>= 2.2.0)
@@ -38,13 +38,13 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.6.3)
-    devise (2.2.3)
+    devise (3.0.3)
       bcrypt-ruby (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (~> 3.1)
-      warden (~> 1.2.1)
+      railties (>= 3.2.6, < 5)
+      warden (~> 1.2.3)
     erubis (2.7.0)
-    execjs (2.0.0)
+    execjs (2.0.1)
     hike (1.2.3)
     i18n (0.6.1)
     journey (1.0.4)
@@ -56,7 +56,7 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    mime-types (1.24)
+    mime-types (1.25)
     multi_json (1.7.9)
     orm_adapter (0.4.0)
     polyglot (0.3.3)
@@ -106,10 +106,10 @@ GEM
       polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.37)
-    uglifier (2.1.2)
+    uglifier (2.2.1)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
-    warden (1.2.1)
+    warden (1.2.3)
       rack (>= 1.0)
 
 PLATFORMS


### PR DESCRIPTION
Since we don't really need the therubyracer unless compiling assets,
it's not really needed in development mode. For this reason we can
safely move it to the assets group.
