### PR TITLE
Fix PreferredPhone failure

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -89,7 +89,7 @@ class Person < ActiveRecord::Base
     when "Mail"
       mail_address && mail_address.full
     when "PreferredPhone"
-      preferred_phone
+      cell_phone
     when "WorkPhone"
       work_phone
     when "Nationality"


### PR DESCRIPTION
There's no preferred_phone attribute for Person anymore.  Use cell_phone for
now, come up with a better preferred phone heuristic later.

Fixes #59
