### PR TITLE
Create civic.json

### DIFF
--- a/civic.json
+++ b/civic.json
@@ -1,0 +1,22 @@
+{
+  "status": "Alpha",
+  "thumbnailUrl":"",
+  "needs": [
+    {"need":"Ruby"},
+    {"need":"Salesforce"},
+    {"need":"Passionate People"}
+  ],
+  "bornAt": "Code for DC",
+  "type": "",
+  "categories": [], 
+  "geography": "Washington, DC",
+  "contact": [
+    {
+      "name": "Marcus Louie",
+      "email": "",
+      "twitter": "@mlouie"
+    }
+  ],
+  "communityPartner": "Bread for City",
+  "moreInfoLink": "https://hackpad.com/Code-for-DC-District-Housing-KlQ2UbX0Imc"
+}


### PR DESCRIPTION
Adding a civic.json, mostly [specification](https://github.com/BetaNYC/civic.json/blob/master/specification.md) compliant, so we can dynamically update the CfA Projects page with data about this project.
