### PR TITLE
Add apartment field, with kinda-smart full address generation

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,8 +1,25 @@
 class Address < ActiveRecord::Base
-  attr_accessible :street, :city, :state, :zip
+
+  attr_accessible :street, :city, :state, :zip, :apt
   has_many :residents, class_name: :person, through: :person, source: :residence
 
-  def full
-    "#{street}, #{city}, #{state}, #{zip}"
+  def apartment
+    case apt
+    when /^\d+[[:alpha:]]?$/ # For a string of digits without "Apartment" or "Unit" in the prefix
+      "##{apt}"
+    when /^\w$/ # For single letter apartment numbers
+      "##{apt}"
+    else # Otherwise, just use whatever they put
+      apt
+    end
   end
+
+  def full
+    if street.to_s.empty? or city.to_s.empty?
+      ""
+    else
+    "#{street}, #{apartment}, #{city}, #{state}, #{zip}".gsub(/( ,)+/, "").strip.sub(/,$/, "")
+    end
+  end
+
 end

--- a/app/views/application/_person_fields.html.erb
+++ b/app/views/application/_person_fields.html.erb
@@ -22,6 +22,7 @@
     <h4>Address</h4>
     <%= builder.fields_for :residence do |residence_builder| %>
       <%= residence_builder.text_field :street, label: "Street address" %>
+      <%= residence_builder.text_field :apt, label: "Apartment" %>
       <%= residence_builder.text_field :city %>
       <%= residence_builder.text_field :state %>
       <%= residence_builder.text_field :zip, label: "Zip code" %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -47,6 +47,7 @@ def make_an_address(address_class=Address)
     city: Faker::Address.city,
     state: Faker::Address.state,
     zip: Faker::Address.zip,
+    apt: ["", "Apartment #{rand 999}", "Unit #{('A'..'Z').to_a.sample}"].sample
   )
 end
 

--- a/test/fixtures/addresses.yml
+++ b/test/fixtures/addresses.yml
@@ -1,7 +1,6 @@
 one:
   id: 1
   street: 111 Fake Street
-  apt: 111
   city: Oneville
   state: DC
   zip: 11111

--- a/test/unit/address_test.rb
+++ b/test/unit/address_test.rb
@@ -1,0 +1,32 @@
+class AddressTest < ActiveSupport::TestCase
+
+  test "is flexible in generating a full address" do
+    @test = Address.new street: "123 Fake Street"
+    assert_equal "", @test.full
+
+    @test.city = "Toon Town"
+    assert_equal "123 Fake Street, Toon Town", @test.full
+
+    @test.state = "Lemuria"
+    assert_equal "123 Fake Street, Toon Town, Lemuria", @test.full
+
+    @test.zip = "24601"
+    assert_equal "123 Fake Street, Toon Town, Lemuria, 24601", @test.full
+
+    @test.apt = "2"
+    assert_equal "123 Fake Street, #2, Toon Town, Lemuria, 24601", @test.full
+
+    @test.apt = "2B"
+    assert_equal "123 Fake Street, #2B, Toon Town, Lemuria, 24601", @test.full
+
+    @test.apt = "AbCdE"
+    assert_equal "123 Fake Street, AbCdE, Toon Town, Lemuria, 24601", @test.full
+
+    @test.apt = "123"
+    assert_equal "123 Fake Street, #123, Toon Town, Lemuria, 24601", @test.full
+
+    @test.apt = "Unit 2"
+    assert_equal "123 Fake Street, Unit 2, Toon Town, Lemuria, 24601", @test.full
+  end
+
+end


### PR DESCRIPTION
If the user puts "123" in the apartment field, then the full address will
include "#123" after the street address.

If the user puts "Apartment 123", then the full address will have "Apartment
123" after the full address.

Fixes #63
