### PR TITLE
Upgraded to Ubuntu 14.04. No longer automatically does bundle install due to bug.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,24 +1,13 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 Vagrant.configure('2') do |config|
-  config.vm.box      = 'precise32'
-  config.vm.box_url  = 'http://files.vagrantup.com/precise32.box'
-  config.vm.hostname = 'rails-dev-box'
-
-  config.vm.provider 'vmware_fusion' do |v, override|
-    override.vm.box     = 'precise64'
-    override.vm.box_url = 'http://files.vagrantup.com/precise64_vmware.box'
-  end
-
-  config.vm.provider 'parallels' do |v, override|
-    override.vm.box = 'parallels/ubuntu-12.04'
-    override.vm.box_url = 'https://vagrantcloud.com/parallels/ubuntu-12.04'
-
-    # Can be running at background, see https://github.com/Parallels/vagrant-parallels/issues/39
-    v.customize ['set', :id, '--on-window-close', 'keep-running']
-  end
+  config.vm.box      = 'ubuntu/trusty64'
+  config.vm.hostname = 'dchousing-dev-box'
 
   config.vm.network :forwarded_port, guest: 3000, host: 3000
+
+  # So that we start in /vagrant when logging in
+  config.vm.provision "shell", path: "puppet/manifests/cdVagrant.sh"
 
   config.vm.provision :puppet do |puppet|
     puppet.manifests_path = 'puppet/manifests'

--- a/puppet/manifests/cdVagrant.sh
+++ b/puppet/manifests/cdVagrant.sh
@@ -1,0 +1,2 @@
+# Add a line to bash rc so that it automatically goes to /vagrant on login
+echo "cd /vagrant" >> /home/vagrant/.bashrc

--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -75,7 +75,7 @@ exec { 'install_ruby':
   # The rvm executable is more suitable for automated installs.
   #
   # use a ruby patch level known to have a binary
-  command => "${as_vagrant} '${home}/.rvm/bin/rvm install ruby-${ruby_version} --binary --autolibs=enabled && rvm alias create default ${ruby_version}'",
+  command => "${as_vagrant} '${home}/.rvm/bin/rvm install ruby-${ruby_version} --binary --autolibs=enabled --max-time 30 && rvm alias create default ${ruby_version}'",
   creates => "${home}/.rvm/bin/ruby",
   require => Exec['install_rvm']
 }
@@ -105,12 +105,14 @@ class dc-housing-setup {
     ensure => latest
   }
 
-  exec { "run_bundle_install":
-    command => "${as_vagrant} ${rubyhome}/bundle install",
-    cwd => "/vagrant",
-    logoutput => true,
-    timeout => 900 # Bundle install takes a while
-  }
+  # Getting a weird "Zlib::BufError buffer error" when calling this automatically
+  # Run it manually by calling "bundle install" after ssh-ing in
+  #exec { "run_bundle_install":
+  #  command => "${as_vagrant} ${rubyhome}/bundle install",
+  #  cwd => "/vagrant",
+  #  logoutput => true,
+  #  timeout => 900 # Bundle install takes a while
+  #}
 
   # Can't quite get this to work, so you'll have to do it manually the first time you log in to the server
   #exec { "rake_setup_db":


### PR DESCRIPTION
Now have to follow the same steps as the other methods:
bundle install
rake db:setup
rails server
(At least it now automatically starts in the correct directory when logging into into the server.)

Make sure you do `vagrant destroy` before doing `vagrant up`
