### PR TITLE
Updating our Salesforce integration

### DIFF
--- a/app/controllers/salesforce_applicants_controller.rb
+++ b/app/controllers/salesforce_applicants_controller.rb
@@ -73,21 +73,21 @@ class SalesforceApplicantsController < ApplicationController
         username: YAML.load_file("config/databasedotcom.yml")["username"],
         password: Rails.application.secrets.salesforce_password
       )
-      c.materialize("Intake__c")
+      c.materialize("Client__c")
     end
 
     def fetch_intake name
-      unless defined? Intake__c
+      unless defined? Client__c
         materialize_intake!
       end
-      Intake__c.find_by_Name(name)
+      Client__c.find_by_Name(name)
     end
 
     def intakes
-      unless defined? Intake__c
+      unless defined? Client__c
         materialize_intake!
       end
-      Intake__c.all
+      Client__c.all
     end
 
     def pull_from_salesforce

--- a/app/models/salesforce_applicant.rb
+++ b/app/models/salesforce_applicant.rb
@@ -3,23 +3,32 @@ class SalesforceApplicant < ActiveRecord::Base
   validates :applicant, presence: true
 
   @@identity_mappings = {
-    first_name: :FirstName__c,
+    first_name: :First_Name__c,
     middle_name: :Middle_Name__c,
-    last_name: :LastName__c,
+    last_name: :Last_Name__c,
     dob: :DOB__c,
+    state_of_birth: :State_of_Birth__c,
+    city_of_birth: :City_of_Birth__c,
     ssn: :SSN__c,
-    cell_phone: :PrimaryPhoneNo__c,
-    home_phone: :AlternatePhoneNo__c,
-    email: :Primary_Email__c,
+    cell_phone: :Primary_Phone__c, # FIXME: type of phone determined by Primary_Phone_Type__c
+    home_phone: :Primary_Phone__c,
+    email: :Email_Address__c,
+    driver_license_number: :Drivers_License_Number__c,
+    driver_license_state: :Drivers_License_State__c,
     gender: :Gender__c,
     race: :Race__c,
+    citizenship: :Immigrant__c,
+    student_status: :Student_Status__c,
+    marital_status: :Marital_Status__c,
+    occupation: :Occupation__c,
+    ethnicity: :Hispanic__c
   }
 
   @@identity_mail_address_mappings = {
-    street: :Address1__c,
-    city: :City__c,
-    state: :State__c,
-    zip: :ZipCode__c,
+    street: :Primary_Address_1__c,
+    city: :Primary_City__c,
+    state: :Primary_State__c,
+    zip: :Primary_Zip_Code__c,
   }
 
   def merge_model(mappings, identity, intake)

--- a/test/controllers/salesforce_applicants_controller_test.rb
+++ b/test/controllers/salesforce_applicants_controller_test.rb
@@ -57,11 +57,11 @@ class SalesforceApplicantsControllerTest < ActionController::TestCase
       [
         FakeIntake.new(
           Name: "one",
-          FirstName__c: "Existing applicant",
+          First_Name__c: "Existing applicant",
         ),
         FakeIntake.new(
           Name: "new",
-          FirstName__c: "New applicant",
+          First_Name__c: "New applicant",
         )
       ]
     )
@@ -80,7 +80,7 @@ class SalesforceApplicantsControllerTest < ActionController::TestCase
     SalesforceApplicantsController.any_instance.stubs(:fetch_intake).returns(
       FakeIntake.new(
         Name: 'one',
-        FirstName__c: 'New first name',
+        First_Name__c: 'New first name',
       )
     )
     get :sync, id: salesforce_applicants(:one)

--- a/test/fake_intake.rb
+++ b/test/fake_intake.rb
@@ -267,20 +267,29 @@ class FakeIntake
 
   # Actually supported attributes so far:
   attr_accessor :Name
-  attr_accessor :FirstName__c
+  attr_accessor :First_Name__c
   attr_accessor :Middle_Name__c
-  attr_accessor :LastName__c
-  attr_accessor :Address1__c
-  attr_accessor :City__c
-  attr_accessor :State__c
-  attr_accessor :ZipCode__c
+  attr_accessor :Last_Name__c
+  attr_accessor :Primary_Address_1__c
+  attr_accessor :Primary_City__c
+  attr_accessor :Primary_State__c
+  attr_accessor :Primary_Zip_Code__c
   attr_accessor :DOB__c
   attr_accessor :SSN__c
-  attr_accessor :PrimaryPhoneNo__c
+  attr_accessor :Primary_Phone__c
   attr_accessor :AlternatePhoneNo__c
-  attr_accessor :Primary_Email__c
+  attr_accessor :Email_Address__c
   attr_accessor :Gender__c
   attr_accessor :Race__c
+  attr_accessor :Drivers_License_Number__c
+  attr_accessor :Drivers_License_State__c
+  attr_accessor :Immigrant__c
+  attr_accessor :Student_Status__c
+  attr_accessor :Marital_Status__c
+  attr_accessor :Occupation__c
+  attr_accessor :Hispanic__c
+  attr_accessor :State_of_Birth__c
+  attr_accessor :City_of_Birth__c
 
   def initialize attrs
     attrs.keys.each do |k|

--- a/test/models/salesforce_applicant_test.rb
+++ b/test/models/salesforce_applicant_test.rb
@@ -15,20 +15,28 @@ class SalesforceApplicantTest < ActiveSupport::TestCase
   def test_merge
     intake = FakeIntake.new(
       Name: "one",
-      FirstName__c: "First",
+      First_Name__c: "First",
       Middle_Name__c: "Middle",
-      LastName__c: "Last",
-      Address1__c: "123 Fake St",
-      City__c: "Washington",
-      State__c: "DC",
-      ZipCode__c: "12345",
+      Last_Name__c: "Last",
+      Primary_Address_1__c: "123 Fake St",
+      Primary_City__c: "Washington",
+      Primary_State__c: "DC",
+      Primary_Zip_Code__c: "12345",
       DOB__c: "1959-02-17",
       SSN__c: "123-45-6789",
-      PrimaryPhoneNo__c: "1234567",
-      AlternatePhoneNo__c: "7654321",
-      Primary_Email__c: "foo@bar.baz",
+      Primary_Phone__c: "1234567",
+      Email_Address__c: "foo@bar.baz",
       Gender__c: "Female",
       Race__c: "Pacific Islander",
+      State_of_Birth__c: "New Hampshire",
+      City_of_Birth__c: "San Francisco",
+      Drivers_License_Number__c: "T12-3456",
+      Drivers_License_State__c: "VA",
+      Immigrant__c: "Sealand",
+      Student_Status__c: "Student",
+      Marital_Status__c: "Married",
+      Occupation__c: "Cobbler",
+      Hispanic__c: "Hispanic",
     )
 
     salesforce_applicant.merge intake
@@ -41,7 +49,7 @@ class SalesforceApplicantTest < ActiveSupport::TestCase
     assert_equal Date.new(1959,02,17), identity.dob
     assert_equal "123-45-6789", identity.ssn
     assert_equal "1234567", identity.cell_phone
-    assert_equal "7654321", identity.home_phone
+    assert_equal "1234567", identity.home_phone
     assert_equal "foo@bar.baz", identity.email
     assert_equal "Pacific Islander", identity.race
 
@@ -50,12 +58,22 @@ class SalesforceApplicantTest < ActiveSupport::TestCase
     assert_equal "DC", identity.mail_address.state
     assert_equal "12345", identity.mail_address.zip
 
+    assert_equal "New Hampshire", identity.state_of_birth
+    assert_equal "San Francisco", identity.city_of_birth
+    assert_equal "T12-3456", identity.driver_license_number
+    assert_equal "VA", identity.driver_license_state
+    assert_equal "Sealand", identity.citizenship
+    assert_equal "Student", identity.student_status
+    assert_equal "Married", identity.marital_status
+    assert_equal "Cobbler", identity.occupation
+    assert_equal "Hispanic", identity.ethnicity
+
     # Updates in Salesforce should overwrite existing fields, unless they are
     # blank
     changed_intake = FakeIntake.new(
       Name: "one",
-      FirstName__c: "New first name",
-      LastName__c: "",
+      First_Name__c: "New first name",
+      Last_Name__c: "",
     )
 
     salesforce_applicant.merge changed_intake


### PR DESCRIPTION
This updates our Salesforce integration by
- Using the Client__c object instead of the Intake__c object.  Note, these are both custom objects created by Bread for the City.  They are making changes to their data model.  They will be actively using the Client__c object going forward instead of Intake__c.
- Pulling in additional data fields from Client__c and mapping them to our model.  They are not yet filling out some of these fields, so they will be blank when we pull the data, but the mappings exist now for when they do.