### PR TITLE
On the list of housing forms, emphasized the Download option

### DIFF
--- a/app/views/housing_forms/index.html.erb
+++ b/app/views/housing_forms/index.html.erb
@@ -21,8 +21,8 @@
     <td><%= housing_form.field_results(@applicant).count %></td>
     <td><%= housing_form.known_fields(@applicant).count %></td>
     <td><%= housing_form.filled_fields(@applicant).count %></td>
+    <td><%= link_to 'Download', download_housing_form_path(housing_form), class: "btn btn-info" %></td>
     <td><%= link_to 'Show', housing_form %></td>
-    <td><%= link_to 'Download', download_housing_form_path(housing_form) %></td>
     <td><%= link_to 'Edit', edit_housing_form_path(housing_form) %></td>
     <td><%= link_to 'Delete', housing_form, method: :delete, data: { confirm: 'Are you sure?' } %></td>
   </tr>


### PR DESCRIPTION
This emphasizes the Download option when a case worker is viewing a list of housing applications they can download.  
- Changes the text Download link to a button
- Moves the button to be first action in the list of actions.

![screen shot 2015-01-29 at 3 32 24 pm](https://cloud.githubusercontent.com/assets/1302023/5965699/147c1e24-a7cc-11e4-985e-68b05225409f.png)
