### PR TITLE
Change valid values of Citizenship #266

### DIFF
--- a/app/helpers/citizenship_helper.rb
+++ b/app/helpers/citizenship_helper.rb
@@ -1,5 +1,5 @@
 module CitizenshipHelper
-  def citizenship
+  def citizenship_statuses
     [
         "US Citizen",
         "Non-Citizen with eligible immigration status",

--- a/app/helpers/citizenship_helper.rb
+++ b/app/helpers/citizenship_helper.rb
@@ -1,0 +1,9 @@
+module CitizenshipHelper
+  def citizenship
+    [
+        "US Citizen",
+        "Non-Citizen with eligible immigration status",
+        "Other"
+    ]
+  end
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -72,7 +72,7 @@ class Person < ActiveRecord::Base
   end
 
   def us_citizen?
-    return "United States" == citizenship
+    return "US Citizen" == citizenship
   end
 
   def preferred_phone

--- a/app/views/people/_demographic.html.erb
+++ b/app/views/people/_demographic.html.erb
@@ -7,7 +7,7 @@
 <%= builder.collection_select :driver_license_state, us_states, :last, :first, label: 'Driver license or non-driver ID state' %>
 <%= builder.collection_select :state_of_birth, us_states, :last, :first %>
 <%= builder.collection_select :country_of_birth, countries, :to_s, :to_s %>
-<%= builder.collection_select :citizenship, countries, :to_s, :to_s %>
+<%= builder.collection_select :citizenship, citizenship, :to_s, :to_s %>
 <%= builder.text_field :driver_license_number, label: "Driver license or non-driver ID number" %>
 
 <% %i(

--- a/app/views/people/_demographic.html.erb
+++ b/app/views/people/_demographic.html.erb
@@ -7,7 +7,7 @@
 <%= builder.collection_select :driver_license_state, us_states, :last, :first, label: 'Driver license or non-driver ID state' %>
 <%= builder.collection_select :state_of_birth, us_states, :last, :first %>
 <%= builder.collection_select :country_of_birth, countries, :to_s, :to_s %>
-<%= builder.collection_select :citizenship, citizenship, :to_s, :to_s %>
+<%= builder.collection_select :citizenship, citizenship_statuses, :to_s, :to_s %>
 <%= builder.text_field :driver_license_number, label: "Driver license or non-driver ID number" %>
 
 <% %i(

--- a/lib/applicant_factory.rb
+++ b/lib/applicant_factory.rb
@@ -23,7 +23,7 @@ module ApplicantFactory
         work_phone: Faker::PhoneNumber.phone_number,
         home_phone: Faker::PhoneNumber.phone_number,
         cell_phone: Faker::PhoneNumber.phone_number,
-        citizenship: Faker::Address.country,
+        citizenship: ["US Citizen", "Non-Citizen with eligible immigration status", "Other"].sample,
         country_of_birth: Faker::Address.country,
         state_of_birth: Faker::Address.state_abbr,
         city_of_birth: Faker::Address.city,

--- a/test/fixtures/people.yml
+++ b/test/fixtures/people.yml
@@ -14,7 +14,7 @@ one:
   mail_address: one
   state_of_birth: VA
   city_of_birth: Springfield
-  citizenship: United States
+  citizenship: US Citizen
   driver_license_number: X12345678
   driver_license_state: NY
   marital_status: Married
@@ -45,7 +45,7 @@ hh1:
   work_phone: 788-243-3188 x97905
   home_phone: 1-437-053-5113 x41799
   cell_phone: 839.897.3785 x24946
-  citizenship: Mayotte
+  citizenship: Other
   country_of_birth: Bosnia and Herzegovina
   email: ryan@parker.info
   race: Native Hawaiian or Other Pacific Islander

--- a/test/unit/field_filling_test.rb
+++ b/test/unit/field_filling_test.rb
@@ -412,7 +412,7 @@ class FieldFillingTest < ActiveSupport::TestCase
   test 'nationality and citizenship are the same' do
     app = applicants(:one)
 
-    assert_equal "United States",    app.field("Citizenship")
-    assert_equal "United States",    app.field("Nationality")
+    assert_equal "US Citizen",    app.field("Citizenship")
+    assert_equal "US Citizen",    app.field("Nationality")
   end
 end


### PR DESCRIPTION
Added app/helpers/citizenship_helper.rb to contain citizenship statuses for form builder.
Modified app/views/people/_demographic.html.erb to change citizenship status values to use citizenship_helper.rb instead of countries_helper.rb.
Modified lib/applicant_factory.rb to seed applicant data with citizenship values instead of countries.