### PR TITLE
Replace tabs with accordion menu

### DIFF
--- a/app/assets/stylesheets/home.css.scss
+++ b/app/assets/stylesheets/home.css.scss
@@ -380,3 +380,38 @@ div.dataTables_filter label {
   margin-left: 0.5em;
   font-size: 20px;
 }
+
+/*** Accordion Menu Styling ***/
+.breadcrumb .active {
+  font-weight: bold;
+}
+
+.panel-primary .panel-heading a:hover {
+  color: #ffffff;
+}
+
+.accordion-list-menu {
+  font-size: 1.0em;
+  padding-left: 20px;
+}
+
+.accordion-list-menu .completion {
+  padding: 10px;
+}
+
+.accordion-list-item {
+  border-bottom:1px solid #eee; 
+  padding-top:10px; 
+  padding-bottom:10px;
+}
+
+.accordion-list-new {
+  padding-top:10px;
+}
+
+/*** Shrink Accordion Menu text on smaller devices ***/
+@media screen and (max-width: 1200px){
+    #accordion h4 {
+      font-size: 1.0em;
+    }
+}

--- a/app/views/application/_breadcrumb.html.erb
+++ b/app/views/application/_breadcrumb.html.erb
@@ -2,7 +2,17 @@
   <li><%= link_to current_user.email, root_path %></li>
   <% if defined? object %>
     <li><%= link_to @current_applicant, @current_applicant %></li>
-    <li><%= object %></li>
+    <li>
+      <span class="active">
+      <% if defined? @model.my_number %>
+        <%=@model.my_number%> -
+      <% end %>      
+    	<%= object %>
+      </span>
+      <% if defined? object.progress %>      
+        <span class="badge"><%= object.progress %>%</span>
+      <% end %>
+    </li>
   <% else %>
     <li><%= @current_applicant %></li>
   <% end %>

--- a/app/views/application/_buttons_save_delete.html.erb
+++ b/app/views/application/_buttons_save_delete.html.erb
@@ -1,0 +1,15 @@
+<input id="submit-direction" name="submit_direction" type="hidden">
+
+<p align="center">
+  <%= link_to 'Delete', basic_path(@model), method: :delete, class: "btn btn-danger", data: { confirm: 'Are you sure?' } %>
+  <%= f.button("Save", { class:"btn btn-primary" }) %>
+</p>
+
+<ul class="pager">
+  <li class="previous submit-previous">
+    <a href="#"><span aria-hidden="true">&larr;</span> Save and go back</a>
+  </li>
+  <li class="next submit-next">
+    <a href="#">Save and continue <span aria-hidden="true">&rarr;</span></a>
+  </li>
+</ul>

--- a/app/views/application/_buttons_update_back.html.erb
+++ b/app/views/application/_buttons_update_back.html.erb
@@ -6,7 +6,7 @@
       <a href="#"><span aria-hidden="true">&larr;</span> Save and go back</a>
     </li>
     <li>
-      <%= f.button("Save", { class:"btn btn-default btn-default" }) %>
+      <%= f.button("Save", { class:"btn btn-primary" }) %>
     </li>
     <li class="next submit-next">
       <a href="#">Save and continue <span aria-hidden="true">&rarr;</span></a>

--- a/app/views/application/_collection_tab_content.html.erb
+++ b/app/views/application/_collection_tab_content.html.erb
@@ -1,14 +1,18 @@
+<ol class="accordion-list-menu">
 <% collection.each_with_index do |item, index| %>
-  <li role="presentation">
-    <a href="<%= edit_path(item) %>">
-      <span class="badge"><%= item.progress %>%</span>
-      <%= "#{index + 1} - #{item}" %>
-    </a>
+  <div class="pull-right completion">
+    <span class="badge"><%= item.progress %>%</span>
+  </div>
+  <li class="accordion-list-item">
+      <a href="<%= edit_path(item) %>">
+        <%= "#{item}" %>
+      </a>
   </li>
 <% end %>
+</ol>
 
-<li role="presentation">
+<div class="accordion-list-new">
   <a href="<%= new_path(collection) %>">
     <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> New
   </a>
-</li>
+</div>

--- a/app/views/application/_form_page.html.erb
+++ b/app/views/application/_form_page.html.erb
@@ -1,3 +1,1 @@
 <%= render 'breadcrumb', object: @model %>
-<%= render 'section_tabs', active_section: @active_section %>
-<%= render 'progress', object: @model %>

--- a/app/views/application/_progress.html.erb
+++ b/app/views/application/_progress.html.erb
@@ -1,5 +1,0 @@
-<div class="progress">
-  <div class="progress-bar progress-bar-success" role="progressbar" style="width: <%= object.progress %>%;">
-    <%= object.progress %>%
-  </div>
-</div>

--- a/app/views/application/_section_tabs.html.erb
+++ b/app/views/application/_section_tabs.html.erb
@@ -1,58 +1,127 @@
-<p>
-<ul class="nav nav-tabs nav-justified">
-  <li role="presentation" class="<%= 'active' if :identity == active_section %>">
-    <a href="<%= edit_identity_path(@applicant) %>">
-      Client
-      <span class="badge"><%= @applicant.identity.progress %>%</span>
-    </a>
-  </li>
-  <li role="presentation" class="dropdown <%= 'active' if :household_members == active_section %>">
-    <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-expanded="false">
-      Household members <span class="badge"><%= @applicant.household_members.count %></span> <span class="caret"></span>
-    </a>
-    <ul class="dropdown-menu" role="menu">
-      <%= render 'collection_tab_content', collection: @applicant.household_members %>
-    </ul>
-  </li>
-  <li role="presentation" class="<%= 'active' if :residences == active_section %>">
-    <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-expanded="false">
-      Residence history <span class="badge"><%= @applicant.residences.count %></span> <span class="caret"></span>
-    </a>
-    <ul class="dropdown-menu" role="menu">
-      <%= render 'collection_tab_content', collection: @applicant.residences %>
-    </ul>
-  </li>
-  <li role="presentation" class="<%= 'active' if :employments == active_section %>">
-    <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-expanded="false">
-      Employment <span class="badge"><%= @applicant.employments.count %></span> <span class="caret"></span>
-    </a>
-    <ul class="dropdown-menu" role="menu">
-      <%= render 'collection_tab_content', collection: @applicant.employments %>
-    </ul>
-  </li>
-  <li role="presentation" class="<%= 'active' if :incomes == active_section %>">
-    <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-expanded="false">
-      Income <span class="badge"><%= @applicant.incomes.count %></span> <span class="caret"></span>
-    </a>
-    <ul class="dropdown-menu" role="menu">
-      <%= render 'collection_tab_content', collection: @applicant.incomes %>
-    </ul>
-  </li>
-  <li role="presentation" class="<%= 'active' if :criminal_histories == active_section %>">
-    <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-expanded="false">
-      Criminal history <span class="badge"><%= @applicant.criminal_histories.count %></span> <span class="caret"></span>
-    </a>
-    <ul class="dropdown-menu" role="menu">
-      <%= render 'collection_tab_content', collection: @applicant.criminal_histories %>
-    </ul>
-  </li>
-  <li role="presentation" class="<%= 'active' if :contacts == active_section %>">
-    <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-expanded="false">
-      Contacts <span class="badge"><%= @applicant.contacts.count %></span> <span class="caret"></span>
-    </a>
-    <ul class="dropdown-menu" role="menu">
-      <%= render 'collection_tab_content', collection: @applicant.contacts %>
-    </ul>
-  </li>
-</ul>
-</p>
+<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+
+  <div class="panel panel-default <%= 'panel-primary' if :identity == active_section %>">
+    <div class="panel-heading" role="tab" id="headingOne">
+      <h4 class="panel-title">
+        <a aria-controls="collapseOne" href="<%= edit_identity_path(@applicant) %>">
+          Client
+        </a>
+      </h4>
+    </div>
+  </div>
+
+  <div class="panel panel-default <%= 'panel-primary' if :household_members == active_section %>">
+    <div class="panel-heading" role="tab" id="headingTwo">
+      <h4 class="panel-title">
+        <a class="collapsed" data-toggle="collapse" data-parent="#accordion" href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
+          Household Members
+          <div class="pull-right">
+            <span class="badge"><%= @applicant.household_members.count %></span>
+            <span class="caret"></span>
+          </div>
+        </a>
+      </h4>
+    </div>
+    <div id="collapseTwo" class="panel-collapse collapse <%= 'in' if :household_members == active_section %>" role="tabpanel" aria-labelledby="headingTwo">
+      <div class="panel-body">
+        <%= render 'collection_tab_content', collection: @applicant.household_members %>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default <%= 'panel-primary' if :residences == active_section %>">
+    <div class="panel-heading" role="tab" id="headingThree">
+      <h4 class="panel-title">
+        <a class="collapsed" data-toggle="collapse" data-parent="#accordion" href="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
+          Residence History
+          <div class="pull-right">
+            <span class="badge"><%= @applicant.residences.count %></span>
+            <span class="caret"></span>
+          </div>
+        </a>
+      </h4>
+    </div>
+    <div id="collapseThree" class="panel-collapse collapse <%= 'in' if :residences == active_section %>" role="tabpanel" aria-labelledby="headingThree">
+      <div class="panel-body">
+        <%= render 'collection_tab_content', collection: @applicant.residences %>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default <%= 'panel-primary' if :employments == active_section %>">
+    <div class="panel-heading" role="tab" id="headingFour">
+      <h4 class="panel-title">
+        <a class="collapsed" data-toggle="collapse" data-parent="#accordion" href="#collapseFour" aria-expanded="false" aria-controls="collapseFour">
+          Employment
+          <div class="pull-right">
+            <span class="badge"><%= @applicant.employments.count %></span> 
+            <span class="caret"></span>
+          </div>
+        </a>
+      </h4>
+    </div>
+    <div id="collapseFour" class="panel-collapse collapse <%= 'in' if :employments == active_section %>" role="tabpanel" aria-labelledby="headingFour">
+      <div class="panel-body">
+        <%= render 'collection_tab_content', collection: @applicant.employments %>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default <%= 'panel-primary' if :incomes == active_section %>">
+    <div class="panel-heading" role="tab" id="headingFive">
+      <h4 class="panel-title">
+        <a class="collapsed" data-toggle="collapse" data-parent="#accordion" href="#collapseFive" aria-expanded="false" aria-controls="collapseFive">
+          Income 
+          <div class="pull-right">
+            <span class="badge"><%= @applicant.incomes.count %></span>
+            <span class="caret"></span>
+          </div>
+        </a>
+      </h4>
+    </div>
+    <div id="collapseFive" class="panel-collapse collapse <%= 'in' if :incomes == active_section %>" role="tabpanel" aria-labelledby="headingFive">
+      <div class="panel-body">
+        <%= render 'collection_tab_content', collection: @applicant.incomes %>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default <%= 'panel-primary' if :criminal_histories == active_section %>">
+    <div class="panel-heading" role="tab" id="headingSix">
+      <h4 class="panel-title">
+        <a class="collapsed" data-toggle="collapse" data-parent="#accordion" href="#collapseSix" aria-expanded="false" aria-controls="collapseSix">
+          Criminal History
+          <div class="pull-right">
+            <span class="badge"><%= @applicant.criminal_histories.count %></span>
+            <span class="caret"></span>
+          </div>
+        </a>
+      </h4>
+    </div>
+    <div id="collapseSix" class="panel-collapse collapse <%= 'in' if :criminal_histories == active_section %>" role="tabpanel" aria-labelledby="headingSix">
+      <div class="panel-body">
+        <%= render 'collection_tab_content', collection: @applicant.criminal_histories %>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default <%= 'panel-primary' if :contacts == active_section %>">
+    <div class="panel-heading" role="tab" id="headingSeven">
+      <h4 class="panel-title">
+        <a class="collapsed" data-toggle="collapse" data-parent="#accordion" href="#collapseSeven" aria-expanded="false" aria-controls="collapseSeven">
+          Contacts 
+          <div class="pull-right">
+            <span class="badge"><%= @applicant.contacts.count %></span>
+            <span class="caret"></span>
+          </div>
+        </a>
+      </h4>
+    </div>
+    <div id="collapseSeven" class="panel-collapse collapse <%= 'in' if :contacts == active_section %>" role="tabpanel" aria-labelledby="headingSeven">
+      <div class="panel-body">
+        <%= render 'collection_tab_content', collection: @applicant.contacts %>
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/app/views/contacts/edit.html.erb
+++ b/app/views/contacts/edit.html.erb
@@ -1,8 +1,16 @@
 <%= render 'form_page' %>
-(<%=@model.my_number%>)
-<%= bootstrap_form_for(@model, url: basic_path(@model)) do |f| %>
-<%= render "fields", f: f %>
-<%= render "buttons_update_back", f: f %>
+
+<div class="row">
+	<div class="col-md-3">
+		<%= render 'section_tabs', active_section: @active_section %>
+	</div>
+	<div class="col-md-9">
+		<%= bootstrap_form_for(@model, url: basic_path(@model)) do |f| %>
+		<%= render "fields", f: f %>
+
+		<%= render "buttons_save_delete", f: f %>
+	</div>
+</div>
+
 <% end %>
 
-<%= link_to 'Delete', basic_path(@model), method: :delete, class: "btn btn-danger", data: { confirm: 'Are you sure?' } %>

--- a/app/views/criminal_histories/edit.html.erb
+++ b/app/views/criminal_histories/edit.html.erb
@@ -1,11 +1,18 @@
 <%= render 'form_page' %>
-(<%=@model.my_number%>)
-<%= bootstrap_form_for(@model, url: basic_path(@model)) do |f| %>
-<%= render "fields", f: f %>
-<%= render "buttons_update_back", f: f %>
-<% end %>
 
-<%= link_to 'Delete', basic_path(@model), method: :delete, class: "btn btn-danger", data: { confirm: 'Are you sure?' } %>
+<div class="row">
+	<div class="col-md-3">
+		<%= render 'section_tabs', active_section: @active_section %>
+	</div>
+	<div class="col-md-9">
+		<%= bootstrap_form_for(@model, url: basic_path(@model)) do |f| %>
+		<%= render "fields", f: f %>
+
+		<%= render "buttons_save_delete", f: f %>
+	</div>
+</div>
+
+<% end %>
 
 <% if @model.errors.any? %>
   <div id="error_explanation">

--- a/app/views/employments/edit.html.erb
+++ b/app/views/employments/edit.html.erb
@@ -1,13 +1,18 @@
 <%= render 'form_page' %>
 
-(<%=@model.my_number%>)
+<div class="row">
+	<div class="col-md-3">
+		<%= render 'section_tabs', active_section: @active_section %>
+	</div>
+	<div class="col-md-9">
+		<%= bootstrap_form_for(@model, url: basic_path(@model)) do |f| %>
+		<%= render "fields", f: f %>
 
-<%= bootstrap_form_for(@model, url: basic_path(@model)) do |f| %>
-<%= render "fields", f: f %>
-<%= render "buttons_update_back", f: f %>
+		<%= render "buttons_save_delete", f: f %>
+	</div>
+</div>
+
 <% end %>
-
-<%= link_to 'Delete', basic_path(@model), method: :delete, class: "btn btn-danger", data: { confirm: 'Are you sure?' } %>
 
 <% if @model.errors.any? %>
   <div id="error_explanation">

--- a/app/views/household_members/edit.html.erb
+++ b/app/views/household_members/edit.html.erb
@@ -1,9 +1,15 @@
 <%= render 'form_page' %>
 
-<%= bootstrap_form_for(@model, url: basic_path(@model)) do |f| %>
-(<%=@model.my_number%>)
-<%= render "fields", f: f %>
-<%= render "buttons_update_back", f: f %>
-<% end %>
+<div class="row">
+	<div class="col-md-3">
+		<%= render 'section_tabs', active_section: @active_section %>
+	</div>
+	<div class="col-md-9">
+		<%= bootstrap_form_for(@model, url: basic_path(@model)) do |f| %>
+		<%= render "fields", f: f %>
 
-<%= link_to 'Delete', basic_path(@model), method: :delete, class: "btn btn-danger", data: { confirm: 'Are you sure?' } %>
+		<%= render "buttons_save_delete", f: f %>
+	</div>
+</div>
+
+<% end %>

--- a/app/views/identity/edit.html.erb
+++ b/app/views/identity/edit.html.erb
@@ -1,7 +1,17 @@
 <%= render 'form_page' %>
-<%= bootstrap_form_for(@applicant.identity, url: identity_path(@applicant)) do |f| %>
-<%= render "fields", f: f %>
-<%= render "buttons_update_back", f: f %>
+
+<div class="row">
+	<div class="col-md-3">
+		<%= render 'section_tabs', active_section: @active_section %>
+	</div>
+	<div class="col-md-9">
+		<%= bootstrap_form_for(@applicant.identity, url: identity_path(@applicant)) do |f| %>
+		<%= render "fields", f: f %>
+
+    <%= render "buttons_update_back", f: f %>
+	</div>
+</div>
+
 <% end %>
 
 <% if @model.errors.any? %>

--- a/app/views/incomes/edit.html.erb
+++ b/app/views/incomes/edit.html.erb
@@ -1,8 +1,15 @@
 <%= render 'form_page' %>
-(<%=@model.my_number%>)
-<%= bootstrap_form_for(@model, url: basic_path(@model)) do |f| %>
-<%= render "fields", f: f %>
-<%= render "buttons_update_back", f: f %>
-<% end %>
 
-<%= link_to 'Delete', basic_path(@model), method: :delete, class: "btn btn-danger", data: { confirm: 'Are you sure?' } %>
+<div class="row">
+	<div class="col-md-3">
+		<%= render 'section_tabs', active_section: @active_section %>
+	</div>
+	<div class="col-md-9">
+		<%= bootstrap_form_for(@model, url: basic_path(@model)) do |f| %>
+		<%= render "fields", f: f %>
+
+		<%= render "buttons_save_delete", f: f %>
+	</div>
+</div>
+
+<% end %>

--- a/app/views/residences/edit.html.erb
+++ b/app/views/residences/edit.html.erb
@@ -1,8 +1,15 @@
 <%= render 'form_page' %>
-(<%=@model.my_number%>)
-<%= bootstrap_form_for(@model, url: basic_path(@model)) do |f| %>
-<%= render "fields", f: f %>
-<%= render "buttons_update_back", f: f %>
-<% end %>
 
-<%= link_to 'Delete', basic_path(@model), method: :delete, class: "btn btn-danger", data: { confirm: 'Are you sure?' } %>
+<div class="row">
+	<div class="col-md-3">
+		<%= render 'section_tabs', active_section: @active_section %>
+	</div>
+	<div class="col-md-9">
+		<%= bootstrap_form_for(@model, url: basic_path(@model)) do |f| %>
+		<%= render "fields", f: f %>
+
+		<%= render "buttons_save_delete", f: f %>
+	</div>
+</div>
+
+<% end %>


### PR DESCRIPTION
Fixes codefordc/districthousing#258.

Updates the edit views to replace the section tabs. Progress
bar moved into the breadcrumb trail. New CSS is added
for the menu items. Save/Delete buttons moved because
with many items (such as 7 sources of income), the buttons
were all the way at the bottom of the page.