### PR TITLE
add homelessness to to_s methods in address and residence models

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -15,7 +15,7 @@ class Address < ActiveRecord::Base
   end
 
   def full
-    if /^homeless/i.match street.to_s
+    if homeless?
       "Homeless"
     elsif street.to_s.empty? or city.to_s.empty?
       ""
@@ -45,6 +45,10 @@ class Address < ActiveRecord::Base
     else
       UnknownField.new
     end
+  end
+
+  def homeless?
+    /homeless/i.match street.to_s 
   end
 
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -15,7 +15,9 @@ class Address < ActiveRecord::Base
   end
 
   def full
-    if street.to_s.empty? or city.to_s.empty?
+    if /^homeless/i.match street.to_s
+      "Homeless"
+    elsif street.to_s.empty? or city.to_s.empty?
       ""
     else
     "#{street}, #{apartment}, #{city}, #{state}, #{zip}".gsub(/( ,)+/, "").strip.sub(/,$/, "")

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -50,5 +50,4 @@ class Address < ActiveRecord::Base
   def homeless?
     /homeless/i.match street.to_s 
   end
-
 end

--- a/app/models/residence.rb
+++ b/app/models/residence.rb
@@ -33,8 +33,12 @@ class Residence < ActiveRecord::Base
   end
 
   def to_s
-    if current
+    if current && /^homeless/i.match(address.to_s)
+     "Currently homeless"
+    elsif current
       "Current residence at #{address}"
+    elsif /homeless/i.match(address.to_s)
+      "Homeless"
     else
       "Residence at #{address}"
     end

--- a/app/models/residence.rb
+++ b/app/models/residence.rb
@@ -68,6 +68,4 @@ class Residence < ActiveRecord::Base
       end
     end
   end
-
-
 end

--- a/app/models/residence.rb
+++ b/app/models/residence.rb
@@ -33,11 +33,11 @@ class Residence < ActiveRecord::Base
   end
 
   def to_s
-    if current && /^homeless/i.match(address.to_s)
+    if current && address.homeless?
      "Currently homeless"
     elsif current
       "Current residence at #{address}"
-    elsif /homeless/i.match(address.to_s)
+    elsif address.homeless?
       "Homeless"
     else
       "Residence at #{address}"
@@ -68,4 +68,6 @@ class Residence < ActiveRecord::Base
       end
     end
   end
+
+
 end

--- a/test/fixtures/addresses.yml
+++ b/test/fixtures/addresses.yml
@@ -27,3 +27,7 @@ empty:
   city:
   state:
   zip:
+
+homeless:
+  street: homeless
+  

--- a/test/models/address_test.rb
+++ b/test/models/address_test.rb
@@ -29,4 +29,11 @@ class AddressTest < ActiveSupport::TestCase
     assert_equal "123 Fake Street, Unit 2, Toon Town, Lemuria, 24601", @test.full
   end
 
+  test "says homeless when street has the word homeless in it" do
+    @homeless = Address.new street: "Homeless"
+    assert_equal "Homeless", @homeless.full 
+
+    @homeless_2 = Address.new street: "Was homeless"
+    assert_equal "Homeless", @homeless_2.full 
+  end
 end

--- a/test/models/residence_test.rb
+++ b/test/models/residence_test.rb
@@ -10,4 +10,26 @@ class ResidenceTest < ActiveSupport::TestCase
     assert residence.valid?, residence.errors.messages
   end
 
+  test 'should display homeless instead of residence if address is homeless or none' do 
+    addr = addresses :homeless
+    assert_equal addr.full, 'Homeless'
+
+    # tests 'currently homeless'
+    residence = Residence.new address_id: addr.id, current: true
+    assert_match /homeless/i, residence.to_s
+
+    # tests 'homeless'
+    residence.current = true
+    assert_match /homeless/i, residence.to_s
+
+    # tests 'Current residence at'
+    addr_1 = addresses :one
+    residence_1 = Residence.new address_id: addr_1.id, current: true
+    assert_match /111 Fake Street/, residence_1.to_s
+
+    # tests noncurrent residence at
+    residence_1.current = false
+    assert_match /111 Fake Street/, residence_1.to_s
+  end
+
 end

--- a/test/models/residence_test.rb
+++ b/test/models/residence_test.rb
@@ -16,7 +16,7 @@ class ResidenceTest < ActiveSupport::TestCase
 
     # tests 'currently homeless'
     residence = Residence.new address_id: addr.id, current: true
-    assert_match /homeless/i, residence.to_s
+    assert_match /currently homeless/i, residence.to_s
 
     # tests 'homeless'
     residence.current = false
@@ -25,7 +25,7 @@ class ResidenceTest < ActiveSupport::TestCase
     # tests 'Current residence at'
     addr_1 = addresses :one
     residence_1 = Residence.new address_id: addr_1.id, current: true
-    assert_match /111 Fake Street/, residence_1.to_s
+    assert_match /Current residence at 111 Fake Street/, residence_1.to_s
 
     # tests noncurrent residence at
     residence_1.current = false

--- a/test/models/residence_test.rb
+++ b/test/models/residence_test.rb
@@ -19,7 +19,7 @@ class ResidenceTest < ActiveSupport::TestCase
     assert_match /homeless/i, residence.to_s
 
     # tests 'homeless'
-    residence.current = true
+    residence.current = false
     assert_match /homeless/i, residence.to_s
 
     # tests 'Current residence at'

--- a/test/models/residence_test.rb
+++ b/test/models/residence_test.rb
@@ -31,5 +31,4 @@ class ResidenceTest < ActiveSupport::TestCase
     residence_1.current = false
     assert_match /111 Fake Street/, residence_1.to_s
   end
-
 end

--- a/test/models/residence_test.rb
+++ b/test/models/residence_test.rb
@@ -16,19 +16,19 @@ class ResidenceTest < ActiveSupport::TestCase
 
     # tests 'currently homeless'
     residence = Residence.new address_id: addr.id, current: true
-    assert_match /currently homeless/i, residence.to_s
+    assert_equal "Currently homeless", residence.to_s
 
     # tests 'homeless'
     residence.current = false
-    assert_match /homeless/i, residence.to_s
+    assert_equal "Homeless", residence.to_s
 
     # tests 'Current residence at'
     addr_1 = addresses :one
     residence_1 = Residence.new address_id: addr_1.id, current: true
-    assert_match /Current residence at 111 Fake Street/, residence_1.to_s
+    assert_equal "Current residence at 111 Fake Street, Oneville, DC, 11111", residence_1.to_s
 
     # tests noncurrent residence at
     residence_1.current = false
-    assert_match /111 Fake Street/, residence_1.to_s
+    assert_equal "Residence at 111 Fake Street, Oneville, DC, 11111", residence_1.to_s
   end
 end


### PR DESCRIPTION
Sorry this took so long! I spent a lot of time trying to get this to run locally to confirm the changes were working right. 

This commit alters methods in the residence and address models so that an address marked as 'Homeless' shows up as such in the view. The display logic is in app/models/residence.rb, starting line 35.

Added a fixture and a test to go with it as well.

This should fix #311 . I couldn't recreate the 'doesn't save' issue either so I'm hoping this passes muster. Let me know if I can do anything else on this or if you'd prefer it implemented a different way. 