### PR TITLE
Add navigation to the dictionary #284

### DIFF
--- a/app/assets/javascripts/dictionary.js.coffee
+++ b/app/assets/javascripts/dictionary.js.coffee
@@ -27,9 +27,7 @@ $ ->
   sidenav.width(sidenav.width())
   # sets up positioning when affix starts and stops
   sidenav.on('affix.bs.affix', ->
-    size = $(window).width()
-    divWidth = $('body > div.container').width()
-    margin = (size - divWidth) / 2
+    margin = $("#page-dashboard").css("padding-right")
     $("#pdf-guide-sidenav").css("right", margin)
     $("#pdf-guide-sidenav").css("position", "")
   )


### PR DESCRIPTION
Sidebar got misplaced when left navbar was added.
This changes the way the right position of the right navigation bar of the dictionary is calculated.

I've commited using the old issue. Did not want to create a new one just for this.