### PR TITLE
Add CSRF token for housing_forms#new

### DIFF
--- a/app/views/housing_forms/new.html.erb
+++ b/app/views/housing_forms/new.html.erb
@@ -1,6 +1,6 @@
 <h1>Add a housing form</h1>
 
-<%= bootstrap_form_for @housing_form, remote: true do |f| %>
+<%= bootstrap_form_for @housing_form, remote: true, authenticity_token: true do |f| %>
 
   <% if @housing_form.errors.any? %>
     <div id="error_explanation">


### PR DESCRIPTION
authenticity tokens aren't added by default when "remote: true" is used, which causes submit to fail.