### PR TITLE
Enable travis CI builds on containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: ruby
 rvm:
   - "2.1.2"
-before_install:
-  - sudo apt-get install -qq pdftk
+
+addons:
+  apt:
+    packages:
+      - pdftk
+
+sudo: false


### PR DESCRIPTION
Our Travis CI builds stopped working.  I'm trying to get it going again
by following instructions at
https://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade