### PR TITLE
Update civic.json file to new specification

### DIFF
--- a/civic.json
+++ b/civic.json
@@ -1,25 +1,36 @@
 {
-  "conformsTo":"http://codefordc.org/resources/specification.html",
-  "status": "Beta",
-  "thumbnailUrl":"https://codefordc.github.io/districthousing/img/district-housing-logo-small.png",
-  "needs": [
-    {"need":"Rails enthusiasts"},
-    {"need":"Salesforce"},
-    {"need":"Passionate People"}
-  ],
-  "bornAt": "Code for DC",
-  "type": "Web App",
-  "categories": [
-    {"category":"Housing"}
-  ],
-  "geography": "Washington, DC",
-  "contact": {
-      "name": "Marcus Louie",
-      "email": "",
-      "twitter": "@mlouie"
-  },
-  "communityPartner": {"Bread for City":"http://www.breadforthecity.org/"},
-  "politicalEntity": {},
-  "governmentPartner": {},
-  "moreInfo": "https://hackpad.com/Code-for-DC-District-Housing-KlQ2UbX0Imc"
+    "name": "District Housing Application Assistant", 
+    "description": "District Housing lets caseworkers help clients apply for Section 8 housing by automatically filling out multiple PDF applications using one online form.", 
+    "license": "MIT", 
+    "status": "Beta", 
+    "type": "Web App", 
+    "homepage": "http://codefordc.github.io/districthousing/", 
+    "repository": "https://github.com/codefordc/districthousing", 
+    "thumbnail": "https://codefordc.github.io/districthousing/img/district-housing-logo-small.png", 
+    "geography": [
+        "Washington, DC"
+    ], 
+    "contact": {
+        "name": "Marcus Louie", 
+        "email": "", 
+        "url": "https://twitter.com/@mlouie"
+    }, 
+    "partners": [
+        {
+            "url": "http://www.breadforthecity.org/", 
+            "name": "Bread for City", 
+            "email": ""
+        }, 
+        {
+            "url": "http://codefordc.org", 
+            "name": "Code for DC", 
+            "email": ""
+        }
+    ], 
+    "data": [], 
+    "keywords": [], 
+    "links": [
+        "https://hackpad.com/Code-for-DC-District-Housing-KlQ2UbX0Imc"
+    ], 
+    "id": "https://raw.githubusercontent.com/DCgov/civic.json/master/schema.json"
 }


### PR DESCRIPTION
Hi, there! Code for DC is moving to an updated civic.json
specification. This pull request formats your existing
civic.json to the new standard.

Feel free to look it over and make any updates.

The new civic.json spec keeps the required fields from the older
one, but has a number of benefits. It:

* removes fields that are hard to maintain and get out of date quickly
* combines partner fields to be more broadly applicable
* is usable by civic tech projects outside of government, as well as inside

You'll see that DC Government is using this standard in its own repos:

https://github.com/dcgov

You can learn more about the specification requirements here:

http://open.dc.gov/civic.json